### PR TITLE
DECAF-161 Add many-to-many relationship support with enhanced decorators

### DIFF
--- a/src/model/decorators.ts
+++ b/src/model/decorators.ts
@@ -317,8 +317,13 @@ export function oneToMany<M extends Model>(
   return Decoration.for(key)
     .define(
       prop(PersistenceKeys.RELATIONS),
-      // @ts-expect-error purposeful override
-      list([clazz, String, Number, BigInt]),
+      list([
+        clazz,
+        String,
+        Number,
+        // @ts-expect-error Bigint is not a constructor
+        BigInt,
+      ]),
       onCreate(oneToManyOnCreate, metadata),
       onUpdate(oneToManyOnUpdate, metadata),
       onDelete(oneToManyOnDelete, metadata),
@@ -357,6 +362,58 @@ export function oneToMany<M extends Model>(
  * @see oneToOne
  */
 export function manyToOne<M extends Model>(
+  clazz: Constructor<M>,
+  cascadeOptions: CascadeMetadata = DefaultCascade,
+  populate = true
+) {
+  Model.register(clazz);
+  const metadata: RelationsMetadata = {
+    class: clazz.name,
+    cascade: cascadeOptions,
+    populate: populate,
+  };
+  const key = Repository.key(PersistenceKeys.MANY_TO_ONE);
+  return Decoration.for(key)
+    .define(
+      prop(PersistenceKeys.RELATIONS),
+      type([clazz.name, String.name, Number.name, BigInt.name]),
+      // onCreate(oneToManyOnCreate, metadata),
+      // onUpdate(oneToManyOnUpdate, metadata),
+      // onDelete(oneToManyOnDelete, metadata),
+      // afterAny(pop, metadata),
+      propMetadata(key, metadata)
+    )
+    .apply();
+}
+/**
+ * @description Defines a many-to-one relationship between models
+ * @summary Decorator that establishes a many-to-one relationship between multiple instances of the current model and another model
+ * @template M - The related model type extending Model
+ * @param {Constructor<M>} clazz - The constructor of the related model class
+ * @param {CascadeMetadata} [cascadeOptions=DefaultCascade] - Options for cascading operations (create, update, delete)
+ * @param {boolean} [populate=true] - If true, automatically populates the relationship when the model is retrieved
+ * @return {Function} A decorator function that can be applied to a class property
+ * @function manyToOne
+ * @category Property Decorators
+ * @example
+ * ```typescript
+ * class Book extends BaseModel {
+ *   @required()
+ *   title!: string;
+ *
+ *   @manyToOne(Author)
+ *   author!: string | Author;
+ * }
+ *
+ * class Author extends BaseModel {
+ *   @required()
+ *   name!: string;
+ * }
+ * ```
+ * @see oneToMany
+ * @see oneToOne
+ */
+export function manyToMany<M extends Model>(
   clazz: Constructor<M>,
   cascadeOptions: CascadeMetadata = DefaultCascade,
   populate = true

--- a/src/model/decorators.ts
+++ b/src/model/decorators.ts
@@ -483,7 +483,7 @@ export function manyToMany<M extends Model>(
   populate = true
 ) {
   // Model.register(clazz as Constructor<M>);
-  const key = Repository.key(PersistenceKeys.MANY_TO_ONE);
+  const key = Repository.key(PersistenceKeys.MANY_TO_MANY);
 
   function manyToManyDec(
     clazz: Constructor<M> | (() => Constructor<M>),
@@ -497,7 +497,7 @@ export function manyToMany<M extends Model>(
     };
     return apply(
       prop(PersistenceKeys.RELATIONS),
-      type([
+      list([
         clazz.name ? clazz.name : (clazz as any),
         String.name,
         Number.name,

--- a/src/persistence/constants.ts
+++ b/src/persistence/constants.ts
@@ -27,28 +27,34 @@ export enum PersistenceKeys {
   /** @description Key for general metadata storage */
   METADATA = "__metadata",
 
+  // Ownership
+  /** @description Key for created-by ownership metadata */
+  OWNERSHIP = "ownership",
+
+  /** @description Key for created-by ownership metadata */
+  CREATED_BY = `${OWNERSHIP}.created-by`,
+
+  /** @description Key for updated-by ownership metadata */
+  UPDATED_BY = `${OWNERSHIP}.updated-by`,
+
+  // Relations
+
   /** @description Key for relations metadata storage */
   RELATIONS = "__relations",
 
-  /** @description Key for clause sequence metadata */
-  CLAUSE_SEQUENCE = "clause-sequence",
+  /** @description Key for relations metadata storage */
+  RELATION = "relation",
 
-  // Ownership
-  /** @description Key for created-by ownership metadata */
-  CREATED_BY = "ownership.created-by",
-
-  /** @description Key for updated-by ownership metadata */
-  UPDATED_BY = "ownership.updated-by",
-
-  // Relations
   /** @description Key for one-to-one relation metadata */
-  ONE_TO_ONE = "relations.one-to-one",
+  ONE_TO_ONE = `${RELATION}.one-to-one`,
 
   /** @description Key for one-to-many relation metadata */
-  ONE_TO_MANY = "relations.one-to-many",
+  ONE_TO_MANY = `${RELATION}.one-to-many`,
 
   /** @description Key for many-to-one relation metadata */
-  MANY_TO_ONE = "relations.many-to-one",
+  MANY_TO_ONE = `${RELATION}.many-to-one`,
+  /** @description Key for many-to-one relation metadata */
+  MANY_TO_MANY = `${RELATION}.many-to-one`,
 
   /** @description Key for populate metadata */
   POPULATE = "populate",


### PR DESCRIPTION
```
### Summary
- Added support for many-to-many relationships in the data model.
- Enhanced TypeORM integration to include custom `JoinTable` decorator.
- Standardized handling of relationship metadata and introduced a `manyToMany` decorator.
- Improved tests for relationship validation and table creation.
- Refactored deprecated elements for more robust implementation.

### Code Changes
- Introduced and tested `JoinTable` and `manyToMany` decorators.
- Restructured metadata keys for better consistency.
- Adjusted related TypeORM and core logic.

### Notes for the Reviewers
- Please verify the implementation of `manyToMany` decorator and its integration with TypeORM.
- Review test cases added for any edge cases that need coverage.

### Checklist
- [ ] Does the code build and run properly?
- [ ] Are the tests for many-to-many relationships sufficient and passing?
- [ ] Has the new decorator been documented where appropriate? 

```