### PR TITLE
DECAF-185 Refactor `Dispatch` and `Adapter` to avoid circular dependencies

### DIFF
--- a/src/identity/utils.ts
+++ b/src/identity/utils.ts
@@ -1,5 +1,5 @@
 import { Constructor, Model } from "@decaf-ts/decorator-validation";
-import { Adapter } from "../persistence/Adapter";
+import { Repository } from "@decaf-ts/db-decorators";
 import { PersistenceKeys } from "../persistence/constants";
 
 /**
@@ -17,7 +17,7 @@ export function getTableName<M extends Model>(
   const obj = model instanceof Model ? model.constructor : model;
 
   const metadata = Reflect.getOwnMetadata(
-    Adapter.key(PersistenceKeys.TABLE),
+    Repository.key(PersistenceKeys.TABLE),
     obj
   );
   if (metadata) {
@@ -27,6 +27,18 @@ export function getTableName<M extends Model>(
     return model.constructor.name;
   }
   return model.name;
+}
+
+export function getColumnName<M extends Model>(
+  model: M,
+  attribute: string
+): string {
+  const metadata = Reflect.getMetadata(
+    Repository.key(PersistenceKeys.COLUMN),
+    model,
+    attribute
+  );
+  return metadata ? metadata : attribute;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,13 @@ import { Injectables } from "@decaf-ts/injectable-decorators";
 // overrides the previous Injectables registry to enable the @repository decorator
 Injectables.setRegistry(new InjectablesRegistry());
 
+// imported first on purpose
+export * from "./repository";
+
 export * from "./identity";
 export * from "./interfaces";
 export * from "./model";
 export * from "./query";
-export * from "./repository";
 export * from "./utils";
 //left to last on purpose
 export * from "./persistence";

--- a/src/persistence/index.ts
+++ b/src/persistence/index.ts
@@ -1,7 +1,9 @@
+// purposely in first place
+export * from "./Dispatch";
+
 export * from "./Adapter";
 export * from "./constants";
 export * from "./decorators";
-export * from "./Dispatch";
 export * from "./errors";
 export * from "./ObserverHandler";
 export * from "./Sequence";

--- a/src/persistence/types.ts
+++ b/src/persistence/types.ts
@@ -1,5 +1,6 @@
 import { BulkCrudOperationKeys, OperationKeys } from "@decaf-ts/db-decorators";
 import { Adapter } from "./Adapter";
+import { Observable } from "../interfaces/index";
 
 /**
  * @description Type representing possible ID formats for database events
@@ -35,3 +36,13 @@ export type ObserverFilter = (
 
 export type InferredAdapterConfig<A> =
   A extends Adapter<infer CONF, any, any, any> ? CONF : never;
+
+export interface AdapterDispatch extends Observable {
+  close(): Promise<void>;
+
+  updateObservers(
+    table: string,
+    event: OperationKeys | BulkCrudOperationKeys | string,
+    id: EventIds
+  ): Promise<void>;
+}

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -27,7 +27,7 @@ import { Sequence } from "../persistence/Sequence";
 import { Condition } from "../query/Condition";
 import { WhereOption } from "../query/options";
 import { OrderBySelector, SelectSelector } from "../query/selectors";
-import { getTableName } from "../identity/utils";
+import { getColumnName, getTableName } from "../identity/utils";
 import { uses } from "../persistence/decorators";
 import { Logger } from "@decaf-ts/logging";
 import { ObserverHandler } from "../persistence/ObserverHandler";
@@ -1169,11 +1169,8 @@ export class Repository<
    * @return {string} The column name for the attribute.
    */
   static column<M extends Model>(model: M, attribute: string): string {
-    const metadata = Reflect.getMetadata(
-      Adapter.key(PersistenceKeys.COLUMN),
-      model,
-      attribute
-    );
-    return metadata ? metadata : attribute;
+    return getColumnName(model, attribute);
   }
 }
+
+if (Adapter) Adapter["_baseRepository"] = Repository;

--- a/src/repository/utils.ts
+++ b/src/repository/utils.ts
@@ -3,7 +3,7 @@ import { Constructor, sf } from "@decaf-ts/decorator-validation";
 import { Adapter } from "../persistence/Adapter";
 import { PersistenceKeys } from "../persistence/constants";
 import { Model } from "@decaf-ts/decorator-validation";
-import { Repository } from "./Repository";
+import { getTableName } from "../identity/utils";
 
 /**
  * @description Generates a unique injectable name for a repository.
@@ -53,5 +53,5 @@ export function generateInjectableNameForRepository<T extends Model>(
         `Could not retrieve flavour from model ${model instanceof Model ? model.constructor.name : model.name}`
       );
   }
-  return sf(PersistenceKeys.INJECTABLE, flavour, Repository.table(model));
+  return sf(PersistenceKeys.INJECTABLE, flavour, getTableName(model));
 }

--- a/tests/unit/repository.utils.test.ts
+++ b/tests/unit/repository.utils.test.ts
@@ -1,8 +1,8 @@
 import "reflect-metadata";
 import { generateInjectableNameForRepository } from "../../src/repository/utils";
 import { PersistenceKeys } from "../../src/persistence/constants";
-import { Adapter } from "../../src/persistence/Adapter";
 import { Repository } from "../../src/repository/Repository";
+import { Adapter } from "../../src/persistence/Adapter";
 import { TestModel } from "./TestModel";
 
 // Group related tests for repository utils


### PR DESCRIPTION
### Description

Refactored the `Dispatch` and `Adapter` structures to remove circular dependencies. Updated the codebase to replace metadata utility usage with `getColumnName` and `getTableName`.